### PR TITLE
fix: add rule for github code box

### DIFF
--- a/src/sites/github.ts
+++ b/src/sites/github.ts
@@ -11,6 +11,7 @@ export default [current => current.endsWith('github.com'), () => {
 
   addCSS('#read-only-cursor-text-area', codeStyles)
   addCSS('.CodeMirror-lines', codeStyles)
+  addCSS('.react-code-text', codeStyles)
   addCSS('.markdown-body', sansStylesImportant)
   addCSS('body', sansStylesImportant)
   addCSS('.code-navigation-cursor', 'display:none')


### PR DESCRIPTION
Fix the misalignment issue caused by font inconsistency shown below:

![Screenshot](https://github.com/user-attachments/assets/4c921df4-4965-4c7d-b889-337abcd3ed58)